### PR TITLE
Fix zoom event for map type plots

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nline-plotlyjs-panel",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Grafana Plotly Plugin",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/PlotlyChart.tsx
+++ b/src/PlotlyChart.tsx
@@ -94,12 +94,10 @@ export const PlotlyChart = forwardRef<any, PlotlyChartProps>(
           })
         }
         onRelayout={(relayoutData: any) => {
-          if (relayoutData['xaxis.range[0]'] || relayoutData['yaxis.range[0]']) {
             onEvent?.({
               type: 'zoom',
               data: relayoutData,
             });
-          }
         }}
       />
     );


### PR DESCRIPTION
For map-type plots like scattermap zoom events don't generate the required properties. This removes the check for those properties. I'm unsure why they are in there, so @jacksongoode if you know that would be helpful.

No comprehensive testing has been done, but the panel now generates zoom events on map plots.